### PR TITLE
Mk/enh permgen

### DIFF
--- a/src/OrbitT/Orbit1.jl
+++ b/src/OrbitT/Orbit1.jl
@@ -35,3 +35,5 @@ end
     o1.elts == o2.elts && o1.vals == o2.vals
 
 @inline Base.first(orb::Orbit1) = orb.elts[1]
+@inline Base.last(orb::Orbit1) = orb.elts[end]
+@inline islast(orb::Orbit1, pt) = pt == last(orb) 

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -61,8 +61,32 @@ function Base.in(g, G::PrmGroup)
     return ifelse(isone(h), true, false)
 end
 
-transversals(K::PrmGroup) = transversals(StabilizerChain(K))
 Base.length(K) = order(K::PrmGroup)
+@doc doc"""
+	transversals(G::PrmGroup)
+> Return the transversals (as a Vector) of a permutation group `G`.
+"""
+transversals(G::PrmGroup) = transversals(StabilizerChain(G))
+
+@doc doc"""
+    perm_by_baseimages(G::PrmGroup, base_images::AbstractVector{<:Integer})
+> Return the unique permutation in `G` determined by to `base_images`
+> (with respect to `base(G)`).
+"""
+function perm_by_baseimages(G::PrmGroup, baseimages::AbstractVector{<:Integer})
+    @boundscheck length(baseimages) == length(base(G))
+	trans = transversals(G)
+	res = one(G)
+
+	for (schr, bi) in zip(trans, baseimages)
+		gr_word = Word(schr.gens_inv, schr.orb, bi, schr.op)
+	    res = gr_word(schr.gens_inv, res)
+		# res = fastmul!(res, res, t[bi])
+	end
+
+    return inv(res)
+end
+
 @doc doc"""
 	degree(G::PrmGroup{I})::I where I
 > Return the degree of `G`, i.e. the length of the storage of permutations in `G`.
@@ -75,4 +99,3 @@ Generic.degree(G::PrmGroup{I}) where I = I(degree(first(gens(G))))
 > Return the identity of a permutation group `G`.
 """
 Base.one(G::PrmGroup) = Perm(degree(G))
-

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -16,11 +16,13 @@ AbstractAlgebra.gens(G::PrmGroup) = G.gens
 > group `G` will construct the chain from `gens(G)` and complete by the
 > deterministic Schreier-Sims algorithm. The subsequent calls just return the
 > cached copy.
+> !!! NOTE: !!! It is users responsibility to ensure that the cached copy is
+> completed by call to `schreier_sims!` if the `base` or `gens` are changed
+> manually after groups creation. 
 """
 function StabilizerChain(G::PrmGroup)
     if !(isdefined(G, :stabchain))
-        G.stabchain = StabilizerChain(gens(G))
-        schreier_sims!(G.stabchain)
+        G.stabchain = schreier_sims!(StabilizerChain(gens(G)))
     end
     return G.stabchain
 end

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -61,7 +61,6 @@ function Base.in(g, G::PrmGroup)
     return ifelse(isone(h), true, false)
 end
 
-Base.length(K) = order(K::PrmGroup)
 @doc doc"""
 	transversals(G::PrmGroup)
 > Return the transversals (as a Vector) of a permutation group `G`.
@@ -99,3 +98,24 @@ Generic.degree(G::PrmGroup{I}) where I = I(degree(first(gens(G))))
 > Return the identity of a permutation group `G`.
 """
 Base.one(G::PrmGroup) = Perm(degree(G))
+
+####################################
+### iteration protocol for PrmGroups
+
+function Base.iterate(G::PrmGroup)
+	return one(G), (deepcopy(base(G)), 1, order(G))
+end
+
+function Base.iterate(G::PrmGroup, state)
+	base_im, count, ord_G = state
+	count == ord_G && return nothing
+
+	basis_im = next!(base_im, transversals(G))
+	g = perm_by_baseimages(G, base_im)
+
+	return (g, (base_im, count+1, ord_G))
+end
+
+Base.eltype(::Type{<:PrmGroup{I}}) where I = Perm{I}
+Base.length(G::PrmGroup) = order(G)
+Base.size(G::PrmGroup) = (length(G),)

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -63,6 +63,16 @@ end
 
 transversals(K::PrmGroup) = transversals(StabilizerChain(K))
 Base.length(K) = order(K::PrmGroup)
+@doc doc"""
+	degree(G::PrmGroup{I})::I where I
+> Return the degree of `G`, i.e. the length of the storage of permutations in `G`.
+> !!! This is an implementation detail and due to change without notice!!!
+"""
 Generic.degree(G::PrmGroup{I}) where I = I(degree(first(gens(G))))
-Base.one(K::PrmGroup{I}) where I = Perm(degree(K))
+
+@doc doc"""
+	one(G::PrmGroup)
+> Return the identity of a permutation group `G`.
+"""
+Base.one(G::PrmGroup) = Perm(degree(G))
 

--- a/src/orbit.jl
+++ b/src/orbit.jl
@@ -40,7 +40,7 @@ for OrbT in [Symbol("Orbit", i) for i in 1:5]
 > Along the points the right transversal is stored as explicit group elements.
 """
         function $OrbT(::Type{Transversal}, gens::Vector{<:GroupElem}, pt::T, op=^) where T
-            orb = $OrbT(pt, parent(first(gens))())
+            orb = $OrbT(pt, one(parent(first(gens))))
             for o in orb
                 for g in gens
                     γ = op(o, g)

--- a/src/schreier-sims.jl
+++ b/src/schreier-sims.jl
@@ -32,9 +32,9 @@ function schreier_sims!(sc::StabilizerChain)
 
                 if found_new_generator
                     for l in (depth+1):new_depth # h fixes all points <= depth
-                        @debug "recomputing Schreier trees..." sc.transversals[l]
+                        @debug "recomputing Schreier trees at level $l ∈ $((depth+1):new_depth)"
                         push!(sc, h, l, recompute=true) # recompute Schreier trees
-                        @debug "...done! new transversal is", sc.transversals[l]
+                        @debug "...done! new transversal is" sc.transversals[l]
                     end
                     @debug "restarting the procedure at depth" new_depth
                     depth = new_depth

--- a/src/schreier.jl
+++ b/src/schreier.jl
@@ -15,6 +15,7 @@ end
 @inline Base.length(schr::Schreier) = length(schr.orb)
 @inline Base.eltype(::Schreier{GEl,I}) where {GEl, I} = I
 @inline Base.first(schr::Schreier) = first(schr.orb)
+@inline Base.last(schr::Schreier) = last(schr.orb)
 @inline islast(schr::Schreier, pt) = islast(schr.orb,pt)
 
 function Base.:(==)(s1::Schreier,s2::Schreier)

--- a/src/schreier.jl
+++ b/src/schreier.jl
@@ -45,7 +45,7 @@ function Schreier(OrbT::Type{<:AbstractOrbit}, gens::Vector{<:GroupElem}, pt, op
         for (idx, g) in enumerate(gens)
             γ = op(o, g)
             if γ ∉ schr
-                push!(schr,(γ, idx))
+                push!(schr,(γ, oftype(pt,idx)))
             end
         end
     end

--- a/src/stabchain.jl
+++ b/src/stabchain.jl
@@ -2,16 +2,16 @@
 # StabilizerChain and Scheier-Sims algorithm
 ###############################################################################
 
-function sift(g::Perm, base::Vector{<:Integer}, transversals::AbstractVector{Orb}) where Orb<:AbstractOrbit
+function sift(g::Perm{I}, base::Vector{<:Integer}, transversals::AbstractVector{Orb}) where {I<:Integer, Orb<:AbstractOrbit}
     h = g
 
     for (i, Δ) in enumerate(transversals)
         β = base[i]^h
-        β ∈ Δ || return h, i
+        β ∈ Δ || return h, I(i)
         # uᵦ = Δ[β]
         h = h*getinv(Δ, β) # assuming: Δ=orbits[i] is based on base[i]
     end
-    return h, length(transversals)+1
+    return h, I(length(transversals)+1)
 end
 
 @doc doc"""
@@ -51,7 +51,7 @@ end
 """
 function StabilizerChain(gens::AbstractVector{Perm{I}}, B::AbstractVector{I}=I[]) where I
     B, S = initial_bsgs(gens, B)
-    T = [Schreier(gs, pt) for (gs, pt) in zip(S, B)]
+    T = [Schreier(gs, pt) for (pt, gs) in zip(B, S)]
     return StabilizerChain(B, S, T)
 end
 

--- a/src/stabchain.jl
+++ b/src/stabchain.jl
@@ -127,33 +127,20 @@ AbstractAlgebra.order(sc::StabilizerChain) = mapreduce(length, *, sc.transversal
 """
 transversals(sc::StabilizerChain) = sc.transversals
 
-function next!(state::AbstractVector{<:Integer}, transversals)
-	goon = true
-	position = length(state) + 1
-	while goon && position > 1
-		position -= 1
+function next!(baseimages::AbstractVector{<:Integer}, transversals)
+	for position in length(baseimages):-1:1
 		t = transversals[position]
-		orbit_points = collect( t.orb )
-		if state[position] == last(orbit_points)
-			state[position] = first(orbit_points)
+		if islast(t, baseimages[position])
+			@debug "last point in orbit: spilling at" position collect(t), baseimages[position]
+			baseimages[position] = first(t)
 		else
-			idx = findfirst(isequal(state[position]), orbit_points)
-			state[position] = orbit_points[idx + 1]
-			goon = false
+			@debug "next point in orbit: incrementing at" position collect(t), baseimages[position]
+			# TODO: replace by next(t, position)
+			orbit_points = collect(t)
+			idx = findfirst(isequal(baseimages[position]), orbit_points)
+			baseimages[position] = orbit_points[idx + 1]
+			break
 		end
 	end
-	if goon
-		return nothing
-	else
-		return state
-	end
-end
-
-function Base.iterate(K::PrmGroup, state::Union{Nothing, AbstractVector{<:Integer}} = base(K) )
-	if state == nothing
-		return nothing
-	else
-		t = transversals(K)
-		return state2element(state, t), next!(state,t)
-	end
+	return baseimages
 end

--- a/src/stabchain.jl
+++ b/src/stabchain.jl
@@ -121,7 +121,11 @@ end
 """
 AbstractAlgebra.order(sc::StabilizerChain) = mapreduce(length, *, sc.transversals, init=big(1))
 
-transversals(sc::StabilizerChain) = sc.transversals 
+@doc doc"""
+	transversals(sc::StabilizerChain)
+> Return the transversals (as a Vector) from stabilizer chain `sc`.
+"""
+transversals(sc::StabilizerChain) = sc.transversals
 
 function next!(state::AbstractVector{<:Integer}, transversals)
 	goon = true
@@ -143,10 +147,6 @@ function next!(state::AbstractVector{<:Integer}, transversals)
 	else
 		return state
 	end
-end
-
-function state2element(state::AbstractVector{<:Integer}, transversals)
-	return prod(inv(transversals[i][state[i]]) for i in 1:length(state))
 end
 
 function Base.iterate(K::PrmGroup, state::Union{Nothing, AbstractVector{<:Integer}} = base(K) )

--- a/src/types.jl
+++ b/src/types.jl
@@ -57,7 +57,7 @@ end
 > * `sgs::Vector{Vector{<:GroupElem}}` → for each of base element the strong generating set of its stabilizer
 > * `Transversals::Vector{<:Schreier}` → for each of base element the Schreier Tree of its orbit
 """
-struct StabilizerChain{I, GEl, Orb, Schr <: Schreier{GEl, I, Orb}}
+struct StabilizerChain{I, GEl, Orb, Op, Schr <: Schreier{GEl, I, Orb, Op}}
     base::Vector{I}
     sgs::Vector{Vector{GEl}}
     transversals::Vector{Schr}
@@ -75,7 +75,10 @@ mutable struct PrmGroup{I<:Integer, SC<:StabilizerChain} <: AbstractAlgebra.Grou
     function PrmGroup(gens::Vector{Generic.Perm{I}}) where I<:Integer
         maxdegree = maximum(degree.(gens))
         new_gens = Generic.emb.(gens, maxdegree)
-        return new{I, StabilizerChain{I, Generic.Perm{I}, Orbit{I,I}}}(new_gens)
+        sc = Schreier([first(new_gens)], 1, ^)
+        return new{I,
+            StabilizerChain{I, Perm{I}, Orbit{I,I}, typeof(^), typeof(sc)}}(
+            new_gens)
     end
 
     function PrmGroup(gens::Vector{Generic.Perm{I}}, sc::SC) where {I<:Integer, SC<:StabilizerChain}

--- a/src/types.jl
+++ b/src/types.jl
@@ -75,7 +75,7 @@ mutable struct PrmGroup{I<:Integer, SC<:StabilizerChain} <: AbstractAlgebra.Grou
     function PrmGroup(gens::Vector{Generic.Perm{I}}) where I<:Integer
         maxdegree = maximum(degree.(gens))
         new_gens = Generic.emb.(gens, maxdegree)
-        sc = Schreier([first(new_gens)], 1, ^)
+        sc = Schreier([first(new_gens)], I(1), ^)
         return new{I,
             StabilizerChain{I, Perm{I}, Orbit{I,I}, typeof(^), typeof(sc)}}(
             new_gens)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,7 +41,7 @@ function gensstring(gens::AbstractVector{<:Perm}; width=96)
     return str
 end
 
-AbstractAlgebra.degree(p::Perm) = length(p.d)
+AbstractAlgebra.degree(p::Perm{I}) where I = I(length(p.d))
 function Generic.emb(p::Generic.Perm{I}, n) where I
     return Generic.emb!(Perm(I(n)), p, 1:degree(p))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,3 +45,12 @@ AbstractAlgebra.degree(p::Perm) = length(p.d)
 function Generic.emb(p::Generic.Perm{I}, n) where I
     return Generic.emb!(Perm(I(n)), p, 1:degree(p))
 end
+
+# TODO: move to AbstractAlgebra
+function fastmul!(out::Perm, g::Perm, h::Perm)
+   out = (out === h ? similar(out) : out)
+   @inbounds for i in eachindex(out.d)
+      out[i] = h[g[i]]
+   end
+   return out
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -54,3 +54,5 @@ function fastmul!(out::Perm, g::Perm, h::Perm)
    end
    return out
 end
+
+Base.one(G::Generic.PermGroup) = G()

--- a/src/words.jl
+++ b/src/words.jl
@@ -45,14 +45,18 @@ end
 > Computes the evaluation of group word `w` as a group element in generators
 > `gens`. Optional `init` element is by default the identity.
 """
-function (pw::Word)(gens::Vector{<:GroupElem}, init=parent(first(gens))())
-    return foldl(*, map(i->gens[i], pw), init=init)
+function (pw::Word)(gens::Vector{<:GroupElem}, init=Perm(degree(first(gens))))
+    res = init
+    @inbounds for i in pw
+        res = fastmul!(res, res, gens[i])
+    end
+    return res
 end
 
 @doc doc"""
     representative(orb, gens, pt, [^])
 > Return a representative of the coset of `Stab(orb)` which takes `first(orb)`
-> to `pt` i.e. an element `r` of `⟨gens⟩` such that `first(orb)^r = pt`.
+> to `pt` i.e. an element `g` of `⟨gens⟩` such that `first(orb)^g = pt`.
 """
 function representative(gens::Vector{<:GroupElem}, orb::AbstractOrbit{I, <:Integer}, pt::I, op=^) where I<:Integer
     gens_inv = inv.(gens)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,11 +181,11 @@ end
 
     for OrbT in OrbitTypes
         schr = Schreier(OrbT, S, pt, ^)
-        @test schr[pt] == G()
+        @test schr[pt] == one(G)
 
         g,h,k = S
 
-        @test representative(S, schr.orb, pt) == G()
+        @test representative(S, schr.orb, pt) == one(G)
         @test representative(S, schr.orb, pt^g) == g
         @test representative(S, schr.orb, (pt^g)^h) == g*h
         @test representative(S, schr.orb, pt^(g*h)) == g*h

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -518,9 +518,9 @@ end
     @test order(K1) == length(uniq_elements) == 720
     @test uniq_elements == elements
 
-	K2 = PrmGroup([perm"(3,4,5)", perm"(1,2,3,4,5)"]) # Alternating group on 5 symbols
+	K2 = PrmGroup(Perm{Int16}[perm"(3,4,5)", perm"(1,2,3,4,5)"]) # Alternating group on 5 symbols
 	elements = [g for g in K2]
-    @test elements isa Vector{Perm{Int64}}
+    @test elements isa Vector{Perm{Int16}}
 	uniq_elements = unique(elements)
     @test order(K2) == length(uniq_elements) == 60
 	@test uniq_elements == elements

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,15 +513,15 @@ end
 @testset "Iterate over PrmGroup" begin
 	K1 = PrmGroup([perm"(5,6)", perm"(1,2,3,4,5,6)"]) # Symmetric group on 6 symbols
 	elements = [g for g in K1]
+    @test elements isa Vector{Perm{Int64}}
 	uniq_elements = unique(elements)
-	@test uniq_elements == elements
-	@test order(K1) == length(uniq_elements) == 720
+    @test order(K1) == length(uniq_elements) == 720
+    @test uniq_elements == elements
 
 	K2 = PrmGroup([perm"(3,4,5)", perm"(1,2,3,4,5)"]) # Alternating group on 5 symbols
-	elements = [g for g in K2]	
-	uniq_elements = unique(elements) 
+	elements = [g for g in K2]
+    @test elements isa Vector{Perm{Int64}}
+	uniq_elements = unique(elements)
+    @test order(K2) == length(uniq_elements) == 60
 	@test uniq_elements == elements
-	@test order(K2) == length(uniq_elements) == 60
-
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,7 +195,6 @@ end
         @test Word(inv.(S), schr.orb, (pt^g)^h) == Word(Int[2,1])
         @test Word(inv.(S), schr.orb, pt^(g*h)) == Word(Int[2,1])
 
-
         z = g*h*k
         δ = pt^z
         @test Word(inv.(S), schr.orb, δ, ^) == Word([3,2,1])
@@ -388,7 +387,44 @@ end
     @test perm"(1,3,4)" in A
 end
 
-@testset "GAP Docs examples" begin
+@testset "Iterate over PrmGroup" begin
+	K1 = PrmGroup([perm"(5,6)", perm"(1,2,3,4,5,6)"]) # Symmetric group on 6 symbols
+	elements = [g for g in K1]
+    @test elements isa Vector{Perm{Int64}}
+	uniq_elements = unique(elements)
+    @test order(K1) == length(uniq_elements) == 720
+    @test uniq_elements == elements
+
+	K2 = PrmGroup(Perm{Int16}[perm"(3,4,5)", perm"(1,2,3,4,5)"]) # Alternating group on 5 symbols
+	elements = [g for g in K2]
+    @test elements isa Vector{Perm{Int16}}
+	uniq_elements = unique(elements)
+    @test order(K2) == length(uniq_elements) == 60
+	@test uniq_elements == elements
+end
+
+function test_perf(G::AbstractAlgebra.Group)
+    s = 0
+    for g in G
+        s += g[1]
+    end
+    return s
+end
+
+@testset "test_perf/benchmark iteration" begin
+
+    G = PermGroup(8)
+    K = PrmGroup([perm"(1,5,6,2,4,8)", perm"(1,3,6)(2,5,7,4)(8)"])
+    @test test_perf(G) == test_perf(K) == 181440
+    @info "Native iteration over S8 group:"
+    @btime test_perf($G)
+    # 17.555 ms (241925 allocations: 23.38 MiB) → 181440
+    @info "Iteration over K ≅ S8 PrmGroup:"
+    @btime test_perf($K)
+    # 66.707 ms (1059707 allocations: 55.61 MiB) → 181440
+end
+
+@testset "GAP Docs examples/benchmarks" begin
 
     cube4 = Perm.([
        [1,9,3,11,5,13,7,15,2,10,4,12,6,14,8,16],
@@ -398,6 +434,7 @@ end
        [3,11,1,9,7,15,5,13,4,12,2,10,8,16,6,14]]
        )
     G = PrmGroup(cube4)
+    @info "Schreier-Sims for Rubik cube-4 group:"
     @btime schreier_sims($(gens(G)));
     @test order(G) == 384
 
@@ -411,6 +448,7 @@ end
     ]
 
     rubik = PrmGroup(rubik_gens)
+    @info "Schreier-Sims for Rubik cube-9 group:"
     @btime schreier_sims($(gens(rubik)));
     @test order(rubik) == 43252003274489856000 # fits Int128
 
@@ -444,6 +482,7 @@ end
 
         SL_4_7 = PrmGroup([a,b])
         @test order(SL_4_7) == 2317591180800
+        @info "Schreier-Sims for SL(4,7):"
         @btime schreier_sims($(gens(SL_4_7)));
         # GAP: 23 ms vs 300ms here
     end
@@ -505,23 +544,8 @@ end
 
         G = PrmGroup([a,b,c,d])
         @test order(G) == 192480
+        @info "Schreier-Sims for a direct-product group:"
         @btime schreier_sims($(gens(G)))
         # GAP: 17 ms vs 50 ms here
     end
-end
-
-@testset "Iterate over PrmGroup" begin
-	K1 = PrmGroup([perm"(5,6)", perm"(1,2,3,4,5,6)"]) # Symmetric group on 6 symbols
-	elements = [g for g in K1]
-    @test elements isa Vector{Perm{Int64}}
-	uniq_elements = unique(elements)
-    @test order(K1) == length(uniq_elements) == 720
-    @test uniq_elements == elements
-
-	K2 = PrmGroup(Perm{Int16}[perm"(3,4,5)", perm"(1,2,3,4,5)"]) # Alternating group on 5 symbols
-	elements = [g for g in K2]
-    @test elements isa Vector{Perm{Int16}}
-	uniq_elements = unique(elements)
-    @test order(K2) == length(uniq_elements) == 60
-	@test uniq_elements == elements
 end


### PR DESCRIPTION
```
using AbstractAlgebra, PermutationGroups
G = PermGroup(8);
K = PrmGroup([perm"(1,5,6,2,4,8)", perm"(1,3,6)(2,5,7,4)(8)"])

function test_perf(G::AbstractAlgebra.Group)
    s = 0
    for g in G
        s += g[1]
    end
    return s
end
@btime test_perf($G)
# 17.555 ms (241925 allocations: 23.38 MiB) → 181440
@btime test_perf($K)
# 60.659 ms (1059706 allocations: 55.61 MiB) → 181440
```
not bad ;-)