### PR TITLE
Fix gens for SymmetricGroup of degree <= 2

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -69,8 +69,14 @@ Base.:(^)(h::Perm, g::Perm) = conj(h,g)
 
 AbstractAlgebra.degree(S::Generic.SymmetricGroup) = S.n
 function AbstractAlgebra.gens(G::Generic.SymmetricGroup{I}) where I
+    if G.n == 1
+        return [one(G)]
+    end
     a = one(G)
     a.d[1], a.d[2] = 2, 1
+    if G.n == 2
+        return [a]
+    end
     b = Perm(circshift(I(1):degree(G), -1))
     return [a, b]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test
 using BenchmarkTools
 
 @testset "PermutationGroups" begin
+    include("utils.jl")
     include("orbit.jl")
     include("schreier.jl")
     include("stabchain.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,6 @@
+@testset "gens for SymmetricGroup" begin
+    @test gens(PermutationGroups.SymmetricGroup(1)) == [Perm(1)]
+    @test gens(PermutationGroups.SymmetricGroup(2)) == [perm"(1,2)"]
+    @test gens(PermutationGroups.SymmetricGroup(3)) == [perm"(1,2)", perm"(1,2,3)"]
+    @test gens(PermutationGroups.SymmetricGroup(4)) == [perm"(1,2)", perm"(1,2,3,4)"]
+end


### PR DESCRIPTION
Before this PR:
```julia
julia> gens(PermutationGroups.SymmetricGroup(1))
ERROR: BoundsError: attempt to access 1-element Array{Int64,1} at index [2]
Stacktrace:
 [1] setindex! at ./array.jl:847 [inlined]
 [2] gens(::AbstractAlgebra.Generic.SymmetricGroup{Int64}) at /home/blegat/.julia/dev/PermutationGroups/src/utils.jl:73
 [3] top-level scope at REPL[34]:1

julia> gens(PermutationGroups.SymmetricGroup(2))
2-element Array{Perm{Int64},1}:
 (1,2)
 (1,2)
```