### PR TITLE
fix: Always extend gens in Schreier-Sims algorithm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PermutationGroups"
 uuid = "8bc5a954-2dfc-11e9-10e6-cd969bffa420"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "tweisser <tillmann.weisser@web.de>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 AbstractPermutations = "36d08e8a-54dd-435f-8c9e-38a475050b11"

--- a/src/schreier_sims.jl
+++ b/src/schreier_sims.jl
@@ -130,8 +130,8 @@ function extend_gens!(
         end
     end
 
-    if length(tr) > l # if there are new points in the orbit
-        push!(stabch.gens, g) # add the new generator and recompute the orbit
+    push!(stabch.gens, g) # add the new generator and
+    if length(tr) > l # recompute the orbit if necessary
         for (idx, δ) in enumerate(orbit(stabch))
             idx ≤ l && continue # moving only the newly added points
             for g in gens(stabch) # now with all generators


### PR DESCRIPTION
i.e. Even if the orbit didn't change immediately
it might in the future!
Incurs ~10% speed penalty.

Note: found by randomized testing in SW.jl