### PR TITLE
add `@inline` to `iterate` methods

### DIFF
--- a/src/orbit.jl
+++ b/src/orbit.jl
@@ -52,8 +52,8 @@ function Base.push!(orb::Orbit, pt; check = true)
 end
 
 Base.length(orb::Orbit) = Base.length(orb.points)
-Base.iterate(orb::Orbit) = Base.iterate(orb.points)
-Base.iterate(orb::Orbit, state) = Base.iterate(orb.points, state)
+@inline Base.iterate(orb::Orbit) = Base.iterate(orb.points)
+@inline Base.iterate(orb::Orbit, state) = Base.iterate(orb.points, state)
 
 Base.last(orb::Orbit) = last(orb.points)
 
@@ -103,8 +103,8 @@ of the stabilizer of `x`.
 abstract type AbstractTransversal{T,S} <: AbstractOrbit{T} end
 
 Base.length(tr::AbstractTransversal) = length(orbit(tr))
-Base.iterate(tr::AbstractTransversal) = iterate(orbit(tr))
-Base.iterate(tr::AbstractTransversal, state) = iterate(orbit(tr), state)
+@inline Base.iterate(tr::AbstractTransversal) = iterate(orbit(tr))
+@inline Base.iterate(tr::AbstractTransversal, state) = iterate(orbit(tr), state)
 Base.last(tr::AbstractTransversal) = last(orbit(tr))
 
 function Base.rand(

--- a/src/perm_group.jl
+++ b/src/perm_group.jl
@@ -137,13 +137,13 @@ basis(G::AbstractPermutationGroup) = basis(StabilizerChain(G))
 
 Base.eltype(::Type{GT}) where {P,GT<:PermGroup{P}} = Permutation{P,GT}
 
-function Base.iterate(G::PermGroup)
+@inline function Base.iterate(G::PermGroup)
     lfs = leafs(StabilizerChain(G))
     σ, st = iterate(lfs)
     return Permutation(σ, G), (lfs, st)
 end
 
-function Base.iterate(G::PermGroup, state)
+@inline function Base.iterate(G::PermGroup, state)
     lfs, st = state
     next = iterate(lfs, st)
     isnothing(next) && return nothing

--- a/src/stabchain.jl
+++ b/src/stabchain.jl
@@ -42,7 +42,7 @@ function GroupsCore.order(::Type{I}, stabch::StabilizerChain) where {I}
 end
 
 # iteration over layers of StabilizerChain
-function Base.iterate(stabch::StabilizerChain, state = stabch)
+@inline function Base.iterate(stabch::StabilizerChain, state = stabch)
     istrivial(state) && return nothing
     return state, stabilizer(state)
 end
@@ -170,7 +170,7 @@ function leafs(stabch::StabilizerChain{P,T}) where {P,T}
     return Leafs(transversals, prod(length, transversals; init = 1))
 end
 
-function Base.iterate(lfs::Leafs{<:AbstractTransversal})
+@inline function Base.iterate(lfs::Leafs{<:AbstractTransversal})
     states = last.(iterate.(lfs.iters))
 
     partial_prods = map(1:length(lfs.iters)-1) do idx
@@ -184,7 +184,7 @@ function Base.iterate(lfs::Leafs{<:AbstractTransversal})
     return res, state
 end
 
-function Base.iterate(lfs::Leafs{<:AbstractTransversal}, state)
+@inline function Base.iterate(lfs::Leafs{<:AbstractTransversal}, state)
     isempty(lfs.iters) && return nothing
     next = iterate(lfs.iters[end], state.states[end])
     depth = length(lfs.iters)


### PR DESCRIPTION
By their very nature, `iterate` methods are not type stable. By inlining them, one can avoid allocations and therefore speed up the code. For the 9 adjacent transpositions of $$S_{10}$$ (analogous to `Sym8_7t` in `test/benchmark.jl`) I get
```
julia> using PermutationGroups, Chairmarks

julia> G = PermGroup(parse.(Perm{UInt16}, ["($(i), $(i+1))" for i in 1:9]));

julia> @b sum(1^g for g in $G)
169.716 ms (14515178 allocs: 553.710 MiB, 12.50% gc time)  # master
138.988 ms (10886378 allocs: 442.968 MiB, 11.53% gc time)  # this PR
```